### PR TITLE
Add GitHub Actions workflow to publish images on release

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,0 +1,119 @@
+name: Publish Docker images on release
+
+# Déclenché à la publication d'une release GitHub. Le tag de la release
+# (ex: v0.3.16) fait partie du nom des images poussées sur DockerHub :
+#   <DOCKER_USER>/rust-devtools-circleci:rust-<version>-<tag_release>
+#
+# Seules les versions Rust dont le dossier ci/circleci/rust-*/ a changé depuis
+# la release précédente sont (re)construites. S'il n'existe pas de release
+# précédente, toutes les versions sont construites.
+on:
+  release:
+    types: [published]
+
+# Nom du dépôt DockerHub (le namespace est fourni par la variable DOCKER_USER).
+env:
+  IMAGE: rust-devtools-circleci
+
+permissions:
+  contents: read
+
+jobs:
+  # ------------------------------------------------------------------------
+  # Détermine la liste des versions Rust à (re)construire pour cette release.
+  # ------------------------------------------------------------------------
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.detect.outputs.matrix }}
+      any: ${{ steps.detect.outputs.any }}
+    steps:
+      - name: Checkout (historique complet pour comparer les tags)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Sélectionner les versions modifiées depuis la release précédente
+        id: detect
+        env:
+          CURRENT_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+
+          # Tag de la release précédente : tag annoté/léger le plus récent
+          # accessible depuis le parent du commit taggé. Vide si introuvable.
+          PREV_TAG="$(git describe --tags --abbrev=0 "${CURRENT_TAG}^" 2>/dev/null || true)"
+
+          if [ -z "$PREV_TAG" ]; then
+            echo "Aucune release précédente détectée -> build de toutes les versions."
+          else
+            echo "Comparaison ${PREV_TAG}..${CURRENT_TAG}"
+          fi
+
+          versions=()
+          for dir in ci/circleci/rust-*/; do
+            ver="$(basename "$dir" | sed 's/^rust-//')"
+            if [ -z "$PREV_TAG" ]; then
+              changed=1
+            elif git diff --quiet "$PREV_TAG" "$CURRENT_TAG" -- "$dir"; then
+              changed=0
+            else
+              changed=1
+            fi
+
+            if [ "$changed" -eq 1 ]; then
+              echo "  + rust-$ver : à construire"
+              versions+=("$ver")
+            else
+              echo "  - rust-$ver : inchangé, ignoré"
+            fi
+          done
+
+          if [ "${#versions[@]}" -eq 0 ]; then
+            echo "Aucune image à construire pour cette release."
+            echo "matrix=[]" >> "$GITHUB_OUTPUT"
+            echo "any=false" >> "$GITHUB_OUTPUT"
+          else
+            matrix="$(printf '%s\n' "${versions[@]}" | jq -R . | jq -s -c .)"
+            echo "Matrice : $matrix"
+            echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+            echo "any=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  # ------------------------------------------------------------------------
+  # Construit et pousse chaque image sélectionnée via Docker Build Cloud.
+  # ------------------------------------------------------------------------
+  docker:
+    needs: detect
+    if: needs.detect.outputs.any == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ${{ fromJSON(needs.detect.outputs.matrix) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PAT }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: cloud
+          endpoint: "corebreaker/main"
+
+      - name: Build and push rust-${{ matrix.version }}
+        uses: docker/build-push-action@v6
+        with:
+          context: ci/circleci/rust-${{ matrix.version }}
+          file: ci/circleci/rust-${{ matrix.version }}/Dockerfile
+          platforms: linux/amd64
+          tags: "${{ vars.DOCKER_USER }}/${{ env.IMAGE }}:rust-${{ matrix.version }}-${{ github.event.release.tag_name }}"
+          # For pull requests, export results to the build cache.
+          # Otherwise, push to a registry.
+          outputs: ${{ github.event_name == 'pull_request' && 'type=cacheonly' || 'type=registry' }}


### PR DESCRIPTION
Add a workflow triggered on release publication that builds the CircleCI Rust devtools images and pushes them to DockerHub through Docker Build Cloud.

A first job detects which Rust versions changed since the previous release tag (by diffing ci/circleci/rust-*/ between the current and previous tags) and exposes them as a matrix; with no previous tag, all versions are built. A second job builds each selected version from its own folder and pushes it as <DOCKER_USER>/rust-devtools-circleci:rust-<version>-<release_tag> for linux/amd64.

Requires the repository variable DOCKER_USER and the secret DOCKER_PAT, plus the Docker Build Cloud endpoint configured in the workflow.