### PR TITLE
Add Rust 1.96.0 image and align older images

### DIFF
--- a/ci/circleci/rust-1.78.0/Dockerfile
+++ b/ci/circleci/rust-1.78.0/Dockerfile
@@ -1,6 +1,6 @@
-FROM rust:1.78.0 as build
-RUN cargo install --version 0.8.19 grcov
-RUN cargo install --version 0.1.5 coveralls
+FROM cimg/rust:1.78.0 AS build
+RUN cargo install --locked --version 0.8.19 grcov
+RUN cargo install --locked --version 0.1.5 coveralls
 
 FROM cimg/rust:1.78.0
 
@@ -14,8 +14,8 @@ RUN sudo apt-get update \
     && sudo usermod -G frederic circleci
 
 COPY --chown=circleci:circleci bin /home/circleci/bin/
-COPY --chown=circleci:circleci --from=build /usr/local/cargo/bin/grcov /home/circleci/.cargo/bin/
-COPY --chown=circleci:circleci --from=build /usr/local/cargo/bin/coveralls /home/circleci/.cargo/bin/
+COPY --chown=circleci:circleci --from=build /home/circleci/.cargo/bin/grcov /home/circleci/.cargo/bin/
+COPY --chown=circleci:circleci --from=build /home/circleci/.cargo/bin/coveralls /home/circleci/.cargo/bin/
 
 RUN rustup toolchain install nightly
 

--- a/ci/circleci/rust-1.80.0/Dockerfile
+++ b/ci/circleci/rust-1.80.0/Dockerfile
@@ -1,6 +1,6 @@
-FROM rust:1.80.0 as build
-RUN cargo install --version 0.8.19 grcov
-RUN cargo install --version 0.1.5 coveralls
+FROM cimg/rust:1.80.0 as build
+RUN cargo install --locked --version 0.8.19 grcov
+RUN cargo install --locked --version 0.1.5 coveralls
 
 FROM cimg/rust:1.80.0
 
@@ -14,8 +14,8 @@ RUN sudo apt-get update \
     && sudo usermod -G frederic circleci
 
 COPY --chown=circleci:circleci bin /home/circleci/bin/
-COPY --chown=circleci:circleci --from=build /usr/local/cargo/bin/grcov /home/circleci/.cargo/bin/
-COPY --chown=circleci:circleci --from=build /usr/local/cargo/bin/coveralls /home/circleci/.cargo/bin/
+COPY --chown=circleci:circleci --from=build /home/circleci/.cargo/bin/grcov /home/circleci/.cargo/bin/
+COPY --chown=circleci:circleci --from=build /home/circleci/.cargo/bin/coveralls /home/circleci/.cargo/bin/
 
 RUN rustup toolchain install nightly
 

--- a/ci/circleci/rust-1.96.0/Dockerfile
+++ b/ci/circleci/rust-1.96.0/Dockerfile
@@ -1,21 +1,24 @@
-FROM cimg/rust:1.79.0 AS build
-RUN cargo install --locked --version 0.8.19 grcov
-RUN cargo install --locked --version 0.1.5 coveralls
+FROM cimg/rust:1.96.0 AS build
 
-FROM cimg/rust:1.79.0
+RUN sudo apt update && sudo apt install -y libgit2-dev
 
-RUN sudo apt-get update \
+RUN cargo install --version 0.10.7 grcov
+RUN cargo install --version 0.2.0 -F libgit coveralls
+
+# ---------------------------------------------------------------------------------------------------------------------
+FROM cimg/rust:1.96.0
+
+RUN sudo apt update \
     && sudo apt install -y \
         pkg-config \
         libssl-dev \
         python3-toml \
     && sudo rm -rf /var/lib/apt/lists/* \
-    && sudo groupadd -g 1000 frederic \
-    && sudo usermod -G frederic circleci
+    && sudo groupadd -g 1000 coveralls \
+    && sudo usermod -G coveralls circleci
 
 COPY --chown=circleci:circleci bin /home/circleci/bin/
 COPY --chown=circleci:circleci --from=build /home/circleci/.cargo/bin/grcov /home/circleci/.cargo/bin/
 COPY --chown=circleci:circleci --from=build /home/circleci/.cargo/bin/coveralls /home/circleci/.cargo/bin/
 
 RUN rustup toolchain install nightly
-

--- a/ci/circleci/rust-1.96.0/bin/coverage.sh
+++ b/ci/circleci/rust-1.96.0/bin/coverage.sh
@@ -1,0 +1,63 @@
+#! /usr/bin/env bash
+GRCOV_ARGS=
+if [ "$1" = "-p" ]; then
+  GRCOV_ARGS=" --prefix-dir '$2'"
+  shift 2
+fi
+
+TEST_ARGS=
+if [ "$1" = "-f" ]; then
+  TEST_ARGS="-F $2"
+  shift 2
+fi
+
+while [ "$1" = "-i" ]; do
+  GRCOV_ARGS="$GRCOV_ARGS --ignore '$2'"
+  shift 2
+done
+
+NAME="$1"
+if [ -z $NAME ]; then
+  NAME=$(get_crate_name.py)
+fi
+
+echo "Name: $NAME"
+
+export CARGO_INCREMENTAL=0
+export RUSTFLAGS="-Cinstrument-coverage -Zprofile -Ccodegen-units=1 -Copt-level=0 -Coverflow-checks=off"
+export LLVM_PROFILE_FILE="default.profraw"
+export CARGO_NET_GIT_FETCH_WITH_CLI=true
+
+echo 'Run tests'
+cargo +nightly test --lib $TEST_ARGS
+if [ $? -ne 0 ]; then
+  exit 1
+fi
+
+mkdir target/coverage >/dev/null 2>&1
+
+echo 'Select files and store them into a Zip archive'
+zip -0 ./target/coverage/cov-binaries.zip $(find target/debug/deps -name "$NAME*.gc*" -print)
+
+COV_CMD='/tmp/do-coverage.sh'
+cat >$COV_CMD <<EOF
+grcov ./target/coverage/cov-binaries.zip \
+  -s . \
+  -b target \
+  -t coveralls+ \
+  --token $COVERALLS_REPO_TOKEN \
+  --excl-line 'unreachable' \
+  --excl-start '// no-coverage:start' \
+  --excl-stop '// no-coverage:stop' \
+  $GRCOV_ARGS \
+  --ignore '*/.cargo/*' \
+  --ignore '*/target/debug/build/*' \
+  --llvm \
+  --ignore-not-existing \
+  -o target/coverage/coveralls.json
+EOF
+
+echo 'Produce file for Coveralls with this command:'
+cat $COV_CMD
+bash $COV_CMD
+

--- a/ci/circleci/rust-1.96.0/bin/get_crate_name.py
+++ b/ci/circleci/rust-1.96.0/bin/get_crate_name.py
@@ -1,0 +1,11 @@
+#! /usr/bin/env python3
+from toml import load
+from sys import exit, stderr
+
+try:
+    cargo = load(open('Cargo.toml'))
+
+    print(cargo['package']['name'].replace('-', '_'))
+except FileNotFoundError:
+    print('This is not a crate', file=stderr)
+    exit(10)


### PR DESCRIPTION
Add the Rust 1.96.0 CircleCI image with grcov 0.10.7 and coveralls 0.2.0 (libgit feature), along with the coverage.sh and get_crate_name.py helper scripts.

Align the 1.78.0, 1.79.0 and 1.80.0 images: build the intermediate stage from cimg/rust to avoid the GLIBC mismatch on copied binaries, add --locked to the cargo install commands, and copy grcov/coveralls from the correct cargo bin path.