### PR TITLE
Rebase CI images on official rust bookworm to cut CVEs and fix grcov …

### DIFF
--- a/ci/circleci/rust-1.78.0/Dockerfile
+++ b/ci/circleci/rust-1.78.0/Dockerfile
@@ -1,21 +1,51 @@
-FROM cimg/rust:1.78.0 AS build
-RUN cargo install --locked --version 0.8.19 grcov
+FROM rust:1.78.0-bookworm AS build
+
+RUN cargo install --locked --version 0.8.20 grcov
 RUN cargo install --locked --version 0.1.5 coveralls
 
-FROM cimg/rust:1.78.0
+# ---------------------------------------------------------------------------------------------------------------------
+FROM rust:1.78.0-bookworm
 
-RUN sudo apt-get update \
-    && sudo apt install -y \
-        pkg-config \
-        libssl-dev \
+# Recrée l'environnement « circleci » fourni par les images cimg/rust (utilisateur circleci + sudo,
+# boîte à outils, PATH) sur la base Rust officielle, qui n'embarque pas les outils conteneur vulnérables.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        sudo \
+        git-lfs \
+        jq \
+        zip \
+        cmake \
         python3-toml \
-    && sudo rm -rf /var/lib/apt/lists/* \
-    && sudo groupadd -g 1000 frederic \
-    && sudo usermod -G frederic circleci
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd -g 1002 circleci \
+    && useradd -m -u 1001 -g 1002 -s /bin/bash circleci \
+    && echo 'circleci ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/50-circleci \
+    && chmod 0440 /etc/sudoers.d/50-circleci \
+    && groupadd -g 1000 coveralls \
+    && usermod -aG coveralls circleci
+
+# Déplace la toolchain Rust dans le home de circleci (comme cimg : ~/.cargo et ~/.rustup) pour que
+# le cache CircleCI de ~/.cargo et l'installation de toolchains par circleci continuent de fonctionner.
+RUN mv /usr/local/rustup /home/circleci/.rustup \
+    && mv /usr/local/cargo /home/circleci/.cargo \
+    && chown -R circleci:circleci /home/circleci/.rustup /home/circleci/.cargo
+
+ENV RUSTUP_HOME=/home/circleci/.rustup \
+    CARGO_HOME=/home/circleci/.cargo \
+    RUST_VERSION=1.78.0 \
+    PATH=/home/circleci/.cargo/bin:/home/circleci/bin:/home/circleci/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+# Debian réinitialise le PATH dans les shells de login (contrairement à Ubuntu/cimg) : on réinjecte les
+# chemins de la boîte à outils via /etc/profile.d pour que cargo/rustc/grcov soient trouvés dans tous les shells.
+RUN printf '%s\n' 'export PATH="/home/circleci/.cargo/bin:/home/circleci/bin:/home/circleci/.local/bin:$PATH"' \
+        > /etc/profile.d/50-rust-devtools.sh \
+    && chmod 0644 /etc/profile.d/50-rust-devtools.sh
 
 COPY --chown=circleci:circleci bin /home/circleci/bin/
-COPY --chown=circleci:circleci --from=build /home/circleci/.cargo/bin/grcov /home/circleci/.cargo/bin/
-COPY --chown=circleci:circleci --from=build /home/circleci/.cargo/bin/coveralls /home/circleci/.cargo/bin/
+COPY --chown=circleci:circleci --from=build /usr/local/cargo/bin/grcov /home/circleci/.cargo/bin/
+COPY --chown=circleci:circleci --from=build /usr/local/cargo/bin/coveralls /home/circleci/.cargo/bin/
+
+USER circleci
+WORKDIR /home/circleci
 
 RUN rustup toolchain install nightly
-

--- a/ci/circleci/rust-1.79.0/Dockerfile
+++ b/ci/circleci/rust-1.79.0/Dockerfile
@@ -1,21 +1,51 @@
-FROM cimg/rust:1.79.0 AS build
-RUN cargo install --locked --version 0.8.19 grcov
+FROM rust:1.79.0-bookworm AS build
+
+RUN cargo install --locked --version 0.8.20 grcov
 RUN cargo install --locked --version 0.1.5 coveralls
 
-FROM cimg/rust:1.79.0
+# ---------------------------------------------------------------------------------------------------------------------
+FROM rust:1.79.0-bookworm
 
-RUN sudo apt-get update \
-    && sudo apt install -y \
-        pkg-config \
-        libssl-dev \
+# Recrée l'environnement « circleci » fourni par les images cimg/rust (utilisateur circleci + sudo,
+# boîte à outils, PATH) sur la base Rust officielle, qui n'embarque pas les outils conteneur vulnérables.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        sudo \
+        git-lfs \
+        jq \
+        zip \
+        cmake \
         python3-toml \
-    && sudo rm -rf /var/lib/apt/lists/* \
-    && sudo groupadd -g 1000 frederic \
-    && sudo usermod -G frederic circleci
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd -g 1002 circleci \
+    && useradd -m -u 1001 -g 1002 -s /bin/bash circleci \
+    && echo 'circleci ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/50-circleci \
+    && chmod 0440 /etc/sudoers.d/50-circleci \
+    && groupadd -g 1000 coveralls \
+    && usermod -aG coveralls circleci
+
+# Déplace la toolchain Rust dans le home de circleci (comme cimg : ~/.cargo et ~/.rustup) pour que
+# le cache CircleCI de ~/.cargo et l'installation de toolchains par circleci continuent de fonctionner.
+RUN mv /usr/local/rustup /home/circleci/.rustup \
+    && mv /usr/local/cargo /home/circleci/.cargo \
+    && chown -R circleci:circleci /home/circleci/.rustup /home/circleci/.cargo
+
+ENV RUSTUP_HOME=/home/circleci/.rustup \
+    CARGO_HOME=/home/circleci/.cargo \
+    RUST_VERSION=1.79.0 \
+    PATH=/home/circleci/.cargo/bin:/home/circleci/bin:/home/circleci/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+# Debian réinitialise le PATH dans les shells de login (contrairement à Ubuntu/cimg) : on réinjecte les
+# chemins de la boîte à outils via /etc/profile.d pour que cargo/rustc/grcov soient trouvés dans tous les shells.
+RUN printf '%s\n' 'export PATH="/home/circleci/.cargo/bin:/home/circleci/bin:/home/circleci/.local/bin:$PATH"' \
+        > /etc/profile.d/50-rust-devtools.sh \
+    && chmod 0644 /etc/profile.d/50-rust-devtools.sh
 
 COPY --chown=circleci:circleci bin /home/circleci/bin/
-COPY --chown=circleci:circleci --from=build /home/circleci/.cargo/bin/grcov /home/circleci/.cargo/bin/
-COPY --chown=circleci:circleci --from=build /home/circleci/.cargo/bin/coveralls /home/circleci/.cargo/bin/
+COPY --chown=circleci:circleci --from=build /usr/local/cargo/bin/grcov /home/circleci/.cargo/bin/
+COPY --chown=circleci:circleci --from=build /usr/local/cargo/bin/coveralls /home/circleci/.cargo/bin/
+
+USER circleci
+WORKDIR /home/circleci
 
 RUN rustup toolchain install nightly
-

--- a/ci/circleci/rust-1.80.0/Dockerfile
+++ b/ci/circleci/rust-1.80.0/Dockerfile
@@ -1,21 +1,51 @@
-FROM cimg/rust:1.80.0 as build
-RUN cargo install --locked --version 0.8.19 grcov
+FROM rust:1.80.0-bookworm AS build
+
+RUN cargo install --locked --version 0.8.20 grcov
 RUN cargo install --locked --version 0.1.5 coveralls
 
-FROM cimg/rust:1.80.0
+# ---------------------------------------------------------------------------------------------------------------------
+FROM rust:1.80.0-bookworm
 
-RUN sudo apt-get update \
-    && sudo apt install -y \
-        pkg-config \
-        libssl-dev \
+# Recrée l'environnement « circleci » fourni par les images cimg/rust (utilisateur circleci + sudo,
+# boîte à outils, PATH) sur la base Rust officielle, qui n'embarque pas les outils conteneur vulnérables.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        sudo \
+        git-lfs \
+        jq \
+        zip \
+        cmake \
         python3-toml \
-    && sudo rm -rf /var/lib/apt/lists/* \
-    && sudo groupadd -g 1000 frederic \
-    && sudo usermod -G frederic circleci
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd -g 1002 circleci \
+    && useradd -m -u 1001 -g 1002 -s /bin/bash circleci \
+    && echo 'circleci ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/50-circleci \
+    && chmod 0440 /etc/sudoers.d/50-circleci \
+    && groupadd -g 1000 coveralls \
+    && usermod -aG coveralls circleci
+
+# Déplace la toolchain Rust dans le home de circleci (comme cimg : ~/.cargo et ~/.rustup) pour que
+# le cache CircleCI de ~/.cargo et l'installation de toolchains par circleci continuent de fonctionner.
+RUN mv /usr/local/rustup /home/circleci/.rustup \
+    && mv /usr/local/cargo /home/circleci/.cargo \
+    && chown -R circleci:circleci /home/circleci/.rustup /home/circleci/.cargo
+
+ENV RUSTUP_HOME=/home/circleci/.rustup \
+    CARGO_HOME=/home/circleci/.cargo \
+    RUST_VERSION=1.80.0 \
+    PATH=/home/circleci/.cargo/bin:/home/circleci/bin:/home/circleci/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+# Debian réinitialise le PATH dans les shells de login (contrairement à Ubuntu/cimg) : on réinjecte les
+# chemins de la boîte à outils via /etc/profile.d pour que cargo/rustc/grcov soient trouvés dans tous les shells.
+RUN printf '%s\n' 'export PATH="/home/circleci/.cargo/bin:/home/circleci/bin:/home/circleci/.local/bin:$PATH"' \
+        > /etc/profile.d/50-rust-devtools.sh \
+    && chmod 0644 /etc/profile.d/50-rust-devtools.sh
 
 COPY --chown=circleci:circleci bin /home/circleci/bin/
-COPY --chown=circleci:circleci --from=build /home/circleci/.cargo/bin/grcov /home/circleci/.cargo/bin/
-COPY --chown=circleci:circleci --from=build /home/circleci/.cargo/bin/coveralls /home/circleci/.cargo/bin/
+COPY --chown=circleci:circleci --from=build /usr/local/cargo/bin/grcov /home/circleci/.cargo/bin/
+COPY --chown=circleci:circleci --from=build /usr/local/cargo/bin/coveralls /home/circleci/.cargo/bin/
+
+USER circleci
+WORKDIR /home/circleci
 
 RUN rustup toolchain install nightly
-

--- a/ci/circleci/rust-1.96.0/Dockerfile
+++ b/ci/circleci/rust-1.96.0/Dockerfile
@@ -1,30 +1,60 @@
-FROM cimg/rust:1.96.0 AS build
+FROM rust:1.96.0-bookworm AS build
 
-RUN sudo apt update && sudo apt install -y libgit2-dev
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libgit2-dev \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN cargo install --version 0.10.7 grcov
 RUN cargo install --version 0.2.0 -F libgit coveralls
 RUN cargo install --version 1.0.3 no-crlf
 
 # ---------------------------------------------------------------------------------------------------------------------
-FROM cimg/rust:1.96.0
+FROM rust:1.96.0-bookworm
 
-RUN sudo apt update \
-    && sudo apt install -y \
-        pkg-config \
-        libssl-dev \
+# Recrée l'environnement « circleci » fourni par les images cimg/rust (utilisateur circleci + sudo,
+# boîte à outils, PATH) sur la base Rust officielle, qui n'embarque pas les outils conteneur vulnérables.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        sudo \
+        git-lfs \
+        jq \
+        zip \
+        cmake \
         python3-toml \
-    && sudo rm -rf /var/lib/apt/lists/* \
-    && sudo groupadd -g 1000 coveralls \
-    && sudo usermod -G coveralls circleci
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd -g 1002 circleci \
+    && useradd -m -u 1001 -g 1002 -s /bin/bash circleci \
+    && echo 'circleci ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/50-circleci \
+    && chmod 0440 /etc/sudoers.d/50-circleci \
+    && groupadd -g 1000 coveralls \
+    && usermod -aG coveralls circleci
 
-ENV RUST_LOG=info
+# Déplace la toolchain Rust dans le home de circleci (comme cimg : ~/.cargo et ~/.rustup) pour que
+# le cache CircleCI de ~/.cargo et l'installation de toolchains par circleci continuent de fonctionner.
+RUN mv /usr/local/rustup /home/circleci/.rustup \
+    && mv /usr/local/cargo /home/circleci/.cargo \
+    && chown -R circleci:circleci /home/circleci/.rustup /home/circleci/.cargo
+
+ENV RUSTUP_HOME=/home/circleci/.rustup \
+    CARGO_HOME=/home/circleci/.cargo \
+    RUST_VERSION=1.96.0 \
+    RUST_LOG=info \
+    PATH=/home/circleci/.cargo/bin:/home/circleci/bin:/home/circleci/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+# Debian réinitialise le PATH dans les shells de login (contrairement à Ubuntu/cimg) : on réinjecte les
+# chemins de la boîte à outils via /etc/profile.d pour que cargo/rustc/grcov soient trouvés dans tous les shells.
+RUN printf '%s\n' 'export PATH="/home/circleci/.cargo/bin:/home/circleci/bin:/home/circleci/.local/bin:$PATH"' \
+        > /etc/profile.d/50-rust-devtools.sh \
+    && chmod 0644 /etc/profile.d/50-rust-devtools.sh
 
 COPY --chown=circleci:circleci bin /home/circleci/bin/
-COPY --chown=circleci:circleci --from=build /home/circleci/.cargo/bin/grcov /home/circleci/.cargo/bin/
-COPY --chown=circleci:circleci --from=build /home/circleci/.cargo/bin/coveralls /home/circleci/.cargo/bin/
-COPY --chown=circleci:circleci --from=build /home/circleci/.cargo/bin/no-crlf /home/circleci/.cargo/bin/
+COPY --chown=circleci:circleci --from=build /usr/local/cargo/bin/grcov /home/circleci/.cargo/bin/
+COPY --chown=circleci:circleci --from=build /usr/local/cargo/bin/coveralls /home/circleci/.cargo/bin/
+COPY --chown=circleci:circleci --from=build /usr/local/cargo/bin/no-crlf /home/circleci/.cargo/bin/
 
-RUN /home/circleci/.cargo/bin/no-crlf -r /home/circleci/bin/
+USER circleci
+WORKDIR /home/circleci
+
+RUN no-crlf -r /home/circleci/bin/
 
 RUN rustup toolchain install nightly


### PR DESCRIPTION
…build on Rust >= 1.80

Rebase les 4 images ci/circleci/rust-{1.78.0,1.79.0,1.80.0,1.96.0} de cimg/rust vers l'image Rust officielle rust:<version>-bookworm, dont la surface de vulnérabilités est bien moindre : sur rust-1.96.0, Docker Scout passe de 66 Critical / 291 High à 6 Critical / 51 High (-91 % / -82 %). Les CVE de cimg provenaient des binaires conteneur Go empaquetés par CircleCI (docker, buildkit, containerd, golang.org/x/*) et d'Ubuntu 22.04, jamais des outils Rust de ce dépôt.

L'environnement fourni par cimg est reconstitué sur la base officielle pour éviter toute régression d'usage : utilisateur circleci (uid 1001, gid 1002) avec sudo NOPASSWD et groupe coveralls, toolchain Rust déplacée sous ~/.cargo et ~/.rustup (cache CircleCI et rustup toolchain install préservés), boîte à outils apt (sudo, git-lfs, jq, zip, cmake, python3-toml) et réinjection du PATH pour les shells de login Debian via /etc/profile.d.

Corrige aussi l'échec de build de rust-1.80.0 : grcov 0.8.19 figeait time 0.3.23 qui ne compile plus sur Rust >= 1.80 (error[E0282]: type annotations needed for Box<_>), remplacé par grcov 0.8.20 dont le Cargo.lock fige time 0.3.36. coveralls reste installé sans -F libgit sur les anciennes images (git2 derrière une feature optionnelle désactivée par défaut).